### PR TITLE
Add Carlo AI advisor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,26 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Carlo AI - Carpet & Flooring Advisor
+
+This project is a simple [Next.js](https://nextjs.org) application that introduces **Carlo**, an AI advisor with over 20 years of experience in carpets and flooring. Carlo provides expert advice and offers installation services anywhere in the UK.
+
+For enquiries, please email [enquiries@bookmycarpet.co.uk](mailto:enquiries@bookmycarpet.co.uk).
 
 ## Getting Started
 
-First, run the development server:
+To run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser to view the app.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+You can edit the main page by modifying `app/page.tsx`. Changes are reflected automatically while running the development server.
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- [Next.js Documentation](https://nextjs.org/docs)
+- [Learn Next.js](https://nextjs.org/learn)
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Deploy the app to the Vercel Platform to share it online.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-4xl font-bold mb-4">Carlo - Carpet & Flooring Advisor</h1>
+      <p className="mb-2">With over 20 years of experience, Carlo provides A-Z knowledge on all matters related to carpets and flooring.</p>
+      <p className="mb-2">Installation services available anywhere in the UK.</p>
+      <p className="mb-2">For enquiries, email <a href="mailto:enquiries@bookmycarpet.co.uk" className="text-blue-600 underline">enquiries@bookmycarpet.co.uk</a>.</p>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "arlo-ai",
+  "name": "carlo-ai",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "arlo-ai",
+      "name": "carlo-ai",
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.3.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "arlo-ai",
+  "name": "carlo-ai",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rebrand project for Carlo the carpet & flooring advisor
- create a simple homepage describing Carlo's services

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b34d1cf488333becaff4b249a487f